### PR TITLE
backend cleanup

### DIFF
--- a/irc_client/backend.py
+++ b/irc_client/backend.py
@@ -3,27 +3,21 @@
 from __future__ import annotations
 import collections
 import dataclasses
-import enum
 import logging
 import queue
 import ssl
 import re
 import socket
 import threading
-import sys
-from typing import Sequence, Any, Union, TYPE_CHECKING, Tuple, List, Optional, NewType
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+import traceback
+from typing import Sequence, Union
 
 
 log = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
-class _Message:
+class _ReceivedAndParsedMessage:
     sender: str | None
     sender_is_server: bool
     command: str
@@ -91,13 +85,13 @@ class ReceivedPrivmsg:
     text: str
 @dataclasses.dataclass
 class ServerMessage:
-    sender: str  # I think this is a hostname. Not sure.
+    sender: str | None  # I think this is a hostname. Not sure.  TODO: can be None?
     # TODO: figure out meaning of command and args
     command: str
     args: list[str]
 @dataclasses.dataclass
 class UnknownMessage:
-    sender: str
+    sender: str | None  # TODO: can be None?
     command: str
     args: list[str]
 # fmt: on
@@ -116,18 +110,6 @@ IrcEvent = Union[
     ServerMessage,
     UnknownMessage,
 ]
-
-_IrcInternalEvent = enum.Enum(
-    "_IrcInternalEvent",
-    [
-        "got_message",
-        "should_join",
-        "should_part",
-        "should_quit",
-        "should_send_privmsg",
-        "should_change_nick",
-    ],
-)
 
 
 class IrcCore:
@@ -152,9 +134,9 @@ class IrcCore:
         self._running = True
 
         self._sock: ssl.SSLSocket | None = None  # see connect()
-        self._linebuffer: collections.deque[str] = collections.deque()
+        self._send_queue: queue.Queue[tuple[bytes, IrcEvent | None]] = queue.Queue()
+        self._recv_buffer: collections.deque[str] = collections.deque()
 
-        self._internal_queue: queue.Queue[tuple[Any, ...]] = queue.Queue()
         self.event_queue: queue.Queue[IrcEvent] = queue.Queue()
 
         # TODO: is automagic RPL_NAMREPLY in an rfc??
@@ -166,13 +148,11 @@ class IrcCore:
         # the replies are collected here before emitting a self_joined event
         self._names_replys: dict[str, list[str]] = {}  # {channel: [nick1, nick2, ...]}
 
-    def _send(self, *parts: str) -> None:
-        data = " ".join(parts).encode("utf-8") + b"\r\n"
-        assert self._sock is not None
-        self._sock.sendall(data)
+    def _send_soon(self, *parts: str, done_event: IrcEvent | None = None) -> None:
+        self._send_queue.put((" ".join(parts).encode("utf-8") + b"\r\n", done_event))
 
     def _recv_line(self) -> str:
-        if not self._linebuffer:
+        if not self._recv_buffer:
             data = bytearray()
 
             # this accepts both \r\n and \n because b'blah blah\r\n' ends
@@ -186,34 +166,84 @@ class IrcCore:
                     raise RuntimeError("Server closed the connection!")
 
             lines = data.decode("utf-8", errors="replace").splitlines()
-            self._linebuffer.extend(lines)
+            self._recv_buffer.extend(lines)
 
-        return self._linebuffer.popleft()
+        return self._recv_buffer.popleft()
 
-    def _add_messages_to_internal_queue(self) -> None:
-        # We need to have this function because it would be very complicated to
-        # wait on two different queues, one for requests to send stuff and one
-        # received messages.
-        try:
-            while self._running:
-                line = self._recv_line()
-                if not line:
-                    # "Empty messages are silently ignored"
-                    # https://tools.ietf.org/html/rfc2812#section-2.3.1
-                    continue
-                if line.startswith("PING"):
-                    self._send(line.replace("PING", "PONG", 1))
-                    continue
-                self._internal_queue.put(
-                    (_IrcInternalEvent.got_message, self._split_line(line))
+    def _handle_received_message(self, msg: _ReceivedAndParsedMessage) -> None:
+        if msg.command == "PRIVMSG":
+            assert msg.sender is not None
+            recipient, text = msg.args
+            self.event_queue.put(ReceivedPrivmsg(msg.sender, recipient, text))
+
+        elif msg.command == "JOIN":
+            assert msg.sender is not None
+            [channel] = msg.args
+            if msg.sender == self.nick:
+                # channel will show up in ui once server finishes sending list of nicks
+                self._names_replys[channel] = []
+            else:
+                self.event_queue.put(UserJoined(msg.sender, channel))
+
+        elif msg.command == "PART":
+            assert msg.sender is not None
+            channel = msg.args[0]
+            reason = msg.args[1] if len(msg.args) >= 2 else None
+            if msg.sender == self.nick:
+                self.event_queue.put(SelfParted(channel))
+            else:
+                self.event_queue.put(UserParted(msg.sender, channel, reason))
+
+        elif msg.command == "NICK":
+            assert msg.sender is not None
+            old = msg.sender
+            [new] = msg.args
+            if old == self.nick:
+                self.nick = new
+                self.event_queue.put(SelfChangedNick(old, new))
+            else:
+                self.event_queue.put(UserChangedNick(old, new))
+
+        elif msg.command == "QUIT":
+            assert msg.sender is not None
+            reason = msg.args[0] if msg.args else None
+            if msg.sender == self.nick:
+                self.event_queue.put(SelfQuit())
+                self._running = False
+            else:
+                self.event_queue.put(UserQuit(msg.sender, reason))
+
+        elif msg.sender_is_server:
+            if msg.command == _RPL_NAMREPLY:
+                # TODO: wtf are the first 2 args?
+                # rfc1459 doesn't mention them, but freenode
+                # gives 4-element msg.args lists
+                channel, names = msg.args[-2:]
+
+                # TODO: don't ignore @ and + prefixes
+                self._names_replys[channel].extend(
+                    name.lstrip("@+") for name in names.split()
                 )
-        finally:
-            assert self._sock is not None
-            self._sock.close()
-            self._sock = None
+
+            elif msg.command == _RPL_ENDOFNAMES:
+                # joining a channel finished
+                channel, human_readable_message = msg.args[-2:]
+                nicks = self._names_replys.pop(channel)
+                self.event_queue.put(SelfJoined(channel, nicks))
+
+            else:
+                # TODO: there must be a better way than relying on MOTD
+                if msg.command == _RPL_ENDOFMOTD:
+                    for channel in self._autojoin:
+                        self.join_channel(channel)
+
+                self.event_queue.put(ServerMessage(msg.sender, msg.command, msg.args))
+
+        else:
+            self.event_queue.put(UnknownMessage(msg.sender, msg.command, msg.args))
 
     @staticmethod
-    def _split_line(line: str) -> _Message:
+    def _split_line(line: str) -> _ReceivedAndParsedMessage:
         if not line.startswith(":"):
             sender_is_server = True  # TODO: when does this code run?
             sender = None
@@ -236,116 +266,39 @@ class IrcCore:
                 temp.append(" ".join(args[n:])[1:])
                 args = temp
                 break
-        return _Message(sender, sender_is_server, command, args)
+        return _ReceivedAndParsedMessage(sender, sender_is_server, command, args)
 
-    def _mainloop(self) -> None:
+    def _recv_loop(self) -> None:
+        try:
+            # TODO: does quitting work in all cases, even during connecting?
+            while self._running:
+                line = self._recv_line()
+                if not line:
+                    # "Empty messages are silently ignored"
+                    # https://tools.ietf.org/html/rfc2812#section-2.3.1
+                    continue
+                if line.startswith("PING"):
+                    self._send_soon(line.replace("PING", "PONG", 1))
+                    continue
+
+                message = self._split_line(line)
+                try:
+                    self._handle_received_message(message)
+                except Exception:
+                    traceback.print_exc()
+        finally:
+            assert self._sock is not None
+            self._sock.close()
+            self._sock = None
+            self.event_queue.put(SelfQuit())
+
+    def _send_loop(self) -> None:
         while self._running:
-            event, *args = self._internal_queue.get()
-            log.debug("got an internal %r event", event)
-
-            if event == _IrcInternalEvent.got_message:
-                msg: _Message
-                [msg] = args
-                if msg.command == "PRIVMSG":
-                    recipient, text = msg.args
-                    self.event_queue.put(
-                        ReceivedPrivmsg(msg.sender, recipient, text))
-
-                elif msg.command == "JOIN":
-                    [channel] = msg.args
-                    if msg.sender == self.nick:
-                        # there are plenty of comments in other
-                        # _names_replys code
-                        self._names_replys[channel] = []
-                    else:
-                        self.event_queue.put(UserJoined(msg.sender, channel))
-
-                elif msg.command == "PART":
-                    channel = msg.args[0]
-                    reason = msg.args[1] if len(msg.args) >= 2 else None
-                    if msg.sender == self.nick:
-                        self.event_queue.put(SelfParted(channel))
-                    else:
-                        self.event_queue.put(UserParted(msg.sender, channel, reason))
-
-                elif msg.command == "NICK":
-                    old = msg.sender
-                    [new] = msg.args
-                    if old == self.nick:
-                        self.nick = new
-                        self.event_queue.put(SelfChangedNick(old, new))
-                    else:
-                        self.event_queue.put(UserChangedNick(old, new))
-
-                elif msg.command == "QUIT":
-                    reason = msg.args[0] if msg.args else None
-                    if msg.sender == self.nick:
-                        self.event_queue.put(SelfQuit())
-                        self._running = False
-                    else:
-                        self.event_queue.put(UserQuit(msg.sender, reason))
-
-                elif msg.sender_is_server:
-                    if msg.command == _RPL_NAMREPLY:
-                        # TODO: wtf are the first 2 args?
-                        # rfc1459 doesn't mention them, but freenode
-                        # gives 4-element msg.args lists
-                        channel, names = msg.args[-2:]
-
-                        # TODO: don't ignore @ and + prefixes
-                        self._names_replys[channel].extend(
-                            name.lstrip("@+") for name in names.split()
-                        )
-
-                    elif msg.command == _RPL_ENDOFNAMES:
-                        # joining a channel finished
-                        channel, human_readable_message = msg.args[-2:]
-                        nicks = self._names_replys.pop(channel)
-                        self.event_queue.put(SelfJoined(channel, nicks))
-
-                    else:
-                        # TODO: there must be a better way than relying on MOTD
-                        if msg.command == _RPL_ENDOFMOTD:
-                            for channel in self._autojoin:
-                                self.join_channel(channel)
-
-                        self.event_queue.put(ServerMessage(msg.sender, msg.command, msg.args))
-
-                else:
-                    self.event_queue.put(UnknownMessage(msg.sender, msg.command, msg.args))
-
-            elif event == _IrcInternalEvent.should_join:
-                [channel] = args
-                self._send("JOIN", channel)
-
-            elif event == _IrcInternalEvent.should_part:
-                channel, reason = args
-                if reason is None:
-                    self._send("PART", channel)
-                else:
-                    # FIXME: the reason thing doesn't seem to work
-                    self._send("PART", channel, ":" + reason)
-
-            elif event == _IrcInternalEvent.should_quit:
-                assert not args
-                self._send("QUIT")
-                self._running = False
-
-            elif event == _IrcInternalEvent.should_send_privmsg:
-                recipient, text = args
-                self._send("PRIVMSG", recipient, ":" + text)
-                self.event_queue.put(SentPrivmsg(recipient, text))
-
-            elif event == _IrcInternalEvent.should_change_nick:
-                [new_nick] = args
-                self._send("NICK", new_nick)
-
-            else:
-                raise RuntimeError("Unrecognized internal event!")
-
-            self._internal_queue.task_done()
-
-        self.event_queue.put(SelfQuit())
+            bytez, done_event = self._send_queue.get()
+            assert self._sock is not None
+            self._sock.sendall(bytez)
+            if done_event is not None:
+                self.event_queue.put(done_event)
 
     # if an exception occurs while connecting, it's raised right away
     # run this in a thread if you don't want blocking
@@ -361,12 +314,12 @@ class IrcCore:
             self._sock.connect((self.host, self.port))
 
             # TODO: what if nick or user are in use? use alternatives?
-            self._send("NICK", self.nick)
-            self._send("USER", self.username, "0", "*", ":" + self.realname)
+            self._send_soon("NICK", self.nick)
+            self._send_soon("USER", self.username, "0", "*", ":" + self.realname)
             print("connected")
         except OSError as e:
             print("connect failed", e)
-            # _add_messages_to_internal_queue() knows how to close the
+            # _recv_loop() knows how to close the
             # socket, but we didn't get to actually run it
             if self._sock is not None:
                 self._sock.close()
@@ -374,26 +327,32 @@ class IrcCore:
             raise e
 
         # it didn't fail
-        threading.Thread(target=self._add_messages_to_internal_queue).start()
-        threading.Thread(target=self._mainloop).start()
+        threading.Thread(target=self._recv_loop).start()
+        threading.Thread(target=self._send_loop).start()
 
     def join_channel(self, channel: str) -> None:
-        self._internal_queue.put((_IrcInternalEvent.should_join, channel))
+        self._send_soon("JOIN", channel)
 
     def part_channel(self, channel: str, reason: str | None = None) -> None:
-        self._internal_queue.put((_IrcInternalEvent.should_part, channel, reason))
+        if reason is None:
+            self._send_soon("PART", channel)
+        else:
+            # FIXME: the reason thing doesn't seem to work
+            self._send_soon("PART", channel, ":" + reason)
 
     def send_privmsg(self, nick_or_channel: str, text: str) -> None:
-        self._internal_queue.put(
-            (_IrcInternalEvent.should_send_privmsg, nick_or_channel, text)
+        self._send_soon(
+            "PRIVMSG",
+            nick_or_channel,
+            ":" + text,
+            done_event=SentPrivmsg(nick_or_channel, text),
         )
 
-    # this doesn't change self.nick right away, but .nick is updated
-    # when the nick name has actually changed
-    # emits a self_changed_nick event on success
+    # emits SelfChangedNick event on success
     def change_nick(self, new_nick: str) -> None:
-        self._internal_queue.put((_IrcInternalEvent.should_change_nick, new_nick))
+        self._send_soon("NICK", new_nick)
 
     # part all channels before calling this
     def quit(self) -> None:
-        self._internal_queue.put((_IrcInternalEvent.should_quit,))
+        self._send_soon("QUIT")
+        self._running = False

--- a/irc_client/backend.py
+++ b/irc_client/backend.py
@@ -96,7 +96,7 @@ class UnknownMessage:
     args: list[str]
 # fmt: on
 
-IrcEvent = Union[
+_IrcEvent = Union[
     SelfJoined,
     SelfChangedNick,
     SelfParted,
@@ -134,10 +134,10 @@ class IrcCore:
         self._running = True
 
         self._sock: ssl.SSLSocket | None = None  # see connect()
-        self._send_queue: queue.Queue[tuple[bytes, IrcEvent | None]] = queue.Queue()
+        self._send_queue: queue.Queue[tuple[bytes, _IrcEvent | None]] = queue.Queue()
         self._recv_buffer: collections.deque[str] = collections.deque()
 
-        self.event_queue: queue.Queue[IrcEvent] = queue.Queue()
+        self.event_queue: queue.Queue[_IrcEvent] = queue.Queue()
 
         # TODO: is automagic RPL_NAMREPLY in an rfc??
         # TODO: what do the rfc's say about huge NAMES replies with more nicks
@@ -148,7 +148,7 @@ class IrcCore:
         # the replies are collected here before emitting a self_joined event
         self._names_replys: dict[str, list[str]] = {}  # {channel: [nick1, nick2, ...]}
 
-    def _send_soon(self, *parts: str, done_event: IrcEvent | None = None) -> None:
+    def _send_soon(self, *parts: str, done_event: _IrcEvent | None = None) -> None:
         self._send_queue.put((" ".join(parts).encode("utf-8") + b"\r\n", done_event))
 
     def _recv_line(self) -> str:

--- a/irc_client/gui.py
+++ b/irc_client/gui.py
@@ -505,7 +505,9 @@ class IrcWidget(ttk.PanedWindow):
                 break
 
             if isinstance(event, backend.SelfJoined):
-                self.add_channel_like(ChannelLikeView(self, event.channel, event.nicklist))
+                self.add_channel_like(
+                    ChannelLikeView(self, event.channel, event.nicklist)
+                )
 
             elif isinstance(event, backend.SelfChangedNick):
                 self._nickbutton["text"] = event.new
@@ -553,7 +555,9 @@ class IrcWidget(ttk.PanedWindow):
                     assert not re.fullmatch(backend.CHANNEL_REGEX, event.recipient)
                     self.add_channel_like(ChannelLikeView(self, event.recipient))
 
-                self._channel_likes[event.recipient].on_privmsg(self.core.nick, event.text)
+                self._channel_likes[event.recipient].on_privmsg(
+                    self.core.nick, event.text
+                )
 
             elif isinstance(event, backend.ReceivedPrivmsg):
                 # sender and recipient are channels or nicks
@@ -570,7 +574,8 @@ class IrcWidget(ttk.PanedWindow):
                     channel_like_name = event.recipient
 
                     mentioned = [
-                        nick.lower() for nick in re.findall(backend.NICK_REGEX, event.text)
+                        nick.lower()
+                        for nick in re.findall(backend.NICK_REGEX, event.text)
                     ]
                     pinged = self.core.nick.lower() in mentioned
                     msg_with_sender = f"<{event.sender}> {event.text}"
@@ -584,7 +589,9 @@ class IrcWidget(ttk.PanedWindow):
             # TODO: do something to unknown messages!! maybe log in backend?
             elif isinstance(event, (backend.ServerMessage, backend.UnknownMessage)):
                 # not strictly a privmsg, but handled the same way
-                self._channel_likes[_SERVER_VIEW_ID].on_privmsg(event.sender, " ".join(event.args))
+                self._channel_likes[_SERVER_VIEW_ID].on_privmsg(
+                    event.sender or "???", " ".join(event.args)
+                )
 
             else:
                 raise ValueError("unknown event type " + repr(event))

--- a/irc_client/gui.py
+++ b/irc_client/gui.py
@@ -518,7 +518,7 @@ class IrcWidget(ttk.PanedWindow):
                 self.remove_channel_like(self._channel_likes[event.channel])
 
             elif isinstance(event, backend.SelfQuit):
-                print("got a self_quit event from core")
+                print("gui got SelfQuit event from core")
                 self._on_quit()
                 self.after_cancel(next_call_id)
                 return  # don't run self.handle_events again
@@ -637,12 +637,8 @@ class IrcWidget(ttk.PanedWindow):
 
     def part_all_channels_and_quit(self) -> None:
         """Call this to get out of IRC."""
-        # the channel is not parted right away, self.core just puts a thing to
-        # a queue and does the actual parting later
-        # that's why there's no need to copy the items
         for name, channel_like in self._channel_likes.items():
             if channel_like.is_channel():
                 # TODO: add a reason here?
                 self.core.part_channel(name)
-        print("calling self.core.quit()")
         self.core.quit()


### PR DESCRIPTION
- Replace internal queue with a simpler send queue.
- Make sure that it is clear from method names which methods send and which receive.
- Use dataclasses instead of Enum+Any for events.